### PR TITLE
404s/etc. not 400s

### DIFF
--- a/app/api/api_v1/endpoints/submission_router.py
+++ b/app/api/api_v1/endpoints/submission_router.py
@@ -22,13 +22,13 @@ def create_submission(
     student = db.query(StudentModel).filter_by(student_onyen=onyen).first()
     assignment = db.query(AssignmentModel).filter_by(id=assignment_id).first()
     if student is None:
-        raise HTTPException(status_code=400, detail="Student does not exist")
+        raise HTTPException(status_code=404, detail="Student does not exist")
     if assignment is None:
-        raise HTTPException(status_code=400, detail="Assignment does not exist")
+        raise HTTPException(status_code=404, detail="Assignment does not exist")
     if not assignment.get_is_released():
-        raise HTTPException(status_code=400, detail="Assignment has not been released")
+        raise HTTPException(status_code=423, detail="Assignment has not been released")
     if assignment.get_is_closed_for_student(db, onyen):
-        raise HTTPException(status_code=400, detail="Assignment is closed for submission")
+        raise HTTPException(status_code=423, detail="Assignment is closed for submission")
     submission = SubmissionModel(
         student_id=student.id,
         assignment_id=assignment_id,


### PR DESCRIPTION
This PR changes the HTTP Status Codes used in the submission_router. Instead of using a 400 for everything, I think it makes more sense to use 404 for the cases where the resource doesn't exist and 423 (Locked) where the resource isn't available because it has been locked away from the student, the reason for which is explained in the `detail` field.