### PR TITLE
Fix/student schema and api host

### DIFF
--- a/app/schemas/student.py
+++ b/app/schemas/student.py
@@ -6,8 +6,8 @@ class StudentSchema(BaseModel):
     student_onyen: str
     first_name: str
     last_name: str
-    join_date: str
-    exit_date: str | None
+    join_date: datetime
+    exit_date: datetime | None
 
     class Config:
         orm_mode = True

--- a/start.py
+++ b/start.py
@@ -51,9 +51,9 @@ def main(host, port, reload):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("--host", default="127.0.0.1", help="The host to bind to.")
-    parser.add_argument("--port", default="8000", help="The port to bind to.")
-    parser.add_argument("--reload", action="store_true", help="Enable auto-reload.")
+    parser.add_argument("-H", "--host", default="0.0.0.0", help="The host to bind to.")
+    parser.add_argument("-p", "--port", default="8000", help="The port to bind to.")
+    parser.add_argument("-r", "--reload", action="store_true", help="Enable auto-reload.")
     args = parser.parse_args()
     
     host = args.host


### PR DESCRIPTION
Fixes a bug where `join_date` and `exit_date` in the student schema were typed incorrectly. Changes the default host to `0.0.0.0` in start.py