### PR TITLE
Create submission endpoint changes

### DIFF
--- a/app/api/api_v1/endpoints/submission_router.py
+++ b/app/api/api_v1/endpoints/submission_router.py
@@ -1,4 +1,5 @@
 from typing import List
+from pydantic import BaseModel
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_pagination import Page
 from fastapi_pagination.ext.sqlalchemy import paginate
@@ -11,28 +12,39 @@ from app.api.deps import get_db
 
 router = APIRouter()
 
+class SubmissionBody(BaseModel):
+    onyen: str
+    assignment_id: int
+    commit_id: str
+
 @router.post("/submission/", response_model=SubmissionSchema)
 def create_submission(
     *,
     db: Session = Depends(get_db),
-    onyen: int,
-    assignment_id: int,
-    commit_id: str
+    submission: SubmissionBody
 ):
-    student = db.query(StudentModel).filter_by(student_onyen=onyen).first()
-    assignment = db.query(AssignmentModel).filter_by(id=assignment_id).first()
+    student = db.query(StudentModel).filter_by(student_onyen=submission.onyen).first()
+    assignment = db.query(AssignmentModel).filter_by(id=submission.assignment_id).first()
+
+    # TODO: We should validate that the submitted commit id actually exists in gitea before persisting it in the database.
+    # We don't want another component of EduHeLx to assume the commit we return exists and crash when it doesn't.
+    # Alternatively, we could bake this logic into the endpoints to get submissions, rather than into this one.
+
     if student is None:
         raise HTTPException(status_code=404, detail="Student does not exist")
     if assignment is None:
         raise HTTPException(status_code=404, detail="Assignment does not exist")
     if not assignment.get_is_released():
-        raise HTTPException(status_code=423, detail="Assignment has not been released")
-    if assignment.get_is_closed_for_student(db, onyen):
-        raise HTTPException(status_code=423, detail="Assignment is closed for submission")
+        raise HTTPException(status_code=403, detail="Assignment has not been released")
+    if not assignment.get_is_available_for_student(db, submission.onyen):
+        raise HTTPException(status_code=403, detail="Assignment has not opened yet")
+    if assignment.get_is_closed_for_student(db, submission.onyen):
+        raise HTTPException(status_code=403, detail="Assignment is closed for submission")
+    
     submission = SubmissionModel(
         student_id=student.id,
-        assignment_id=assignment_id,
-        commit_id=commit_id
+        assignment_id=submission.assignment_id,
+        commit_id=submission.commit_id
     )
     
     db.add(submission)


### PR DESCRIPTION
- Fix onyen: int -> str
- Change create submission args to json body, instead of query params
- Verify that the assignment has opened for a student
- Change 423 -> 403 error codes
  - 423 traditionally implies that another person has placed a lock on a file (e.g. someone editing a file), which isn't really what we're trying to indicate here.