### PR TITLE
LDAP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,3 +17,12 @@ POSTGRES_DB=postgres
 POSTGRES_USER=postgres
 # Postgres password
 POSTGRES_PASSWORD=postgres
+# Production host
+LDAP_HOST="ldap.unc.edu"
+# SSL port
+LDAP_PORT=636
+# Essentially the "username" of our service account
+LDAP_SERVICE_ACCOUNT_BIND_DN="cn=unc:app:renci:eduhelx,ou=Applications,dc=unc,dc=edu"
+LDAP_SERVICE_ACCOUNT_PASSWORD="<password>"
+# If a connection cannot be established within this time frame, it will throw an error.
+LDAP_TIMEOUT_SECONDS=5

--- a/app/api/api_v1/endpoints/user_router.py
+++ b/app/api/api_v1/endpoints/user_router.py
@@ -3,8 +3,10 @@
 from fastapi import APIRouter, Request, Depends
 from sqlalchemy.orm import Session
 from app.schemas import StudentSchema, InstructorSchema
-from app.services import UserService
-from app.core.dependencies import get_db
+from app.services import UserService, LDAPService
+from app.services.ldap_service import LDAPUserInfoSchema
+from app.core.dependencies import get_db, PermissionDependency, UserIsSuperuserPermission
+
 
 router = APIRouter()
 
@@ -17,3 +19,12 @@ async def get_own_user(
     onyen = request.user.onyen
     user = await UserService(db).get_user_by_onyen(onyen)
     return user
+
+@router.get("/users/{pid:str}/ldap", response_model=LDAPUserInfoSchema)
+async def get_ldap_user(
+    *,
+    request: Request,
+    perm: None = Depends(PermissionDependency(UserIsSuperuserPermission)),
+    pid: str
+):
+    return LDAPService().get_user_info(pid)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,10 +40,10 @@ class Settings(BaseSettings):
 
     # LDAP
     LDAP_HOST: str
-    LDAP_PORT: str
+    LDAP_PORT: int
     LDAP_SERVICE_ACCOUNT_BIND_DN: str
     LDAP_SERVICE_ACCOUNT_PASSWORD: str
-    LDAP_TIMEOUT_SECONDS: float
+    LDAP_TIMEOUT_SECONDS: int = 5
 
     # Database
     POSTGRES_HOST: str

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -38,6 +38,13 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRES_MINUTES: int = 30 # 30 minutes
     REFRESH_TOKEN_EXPIRES_MINUTES: int = 60 * 24 * 30 # 1 month
 
+    # LDAP
+    LDAP_HOST: str
+    LDAP_PORT: str
+    LDAP_SERVICE_ACCOUNT_BIND_DN: str
+    LDAP_SERVICE_ACCOUNT_PASSWORD: str
+    LDAP_TIMEOUT_SECONDS: float
+
     # Database
     POSTGRES_HOST: str
     POSTGRES_PORT: str = "5432"

--- a/app/core/dependencies/permission.py
+++ b/app/core/dependencies/permission.py
@@ -12,7 +12,7 @@ from app.models import StudentModel, InstructorModel
 from app.core.role_permissions import UserPermission
 from app.core.exceptions import (
     UnauthorizedException, MissingPermissionException, UserNotFoundException,
-    NotAStudentException, NotAnInstructorException
+    NotAStudentException, NotAnInstructorException, NotASuperuserException
 )
 
 class BasePermission(ABC):
@@ -43,6 +43,17 @@ class UserIsInstructorPermission(RequireLoginPermission):
 
         if not isinstance(self.user, InstructorModel):
             raise NotAnInstructorException()
+        
+# We'll define a superuser here as anything other than a student.
+# This definition is useful in endpoints where we want to allow
+# access to everyone other than students without restricting access
+# to just instructors. 
+class UserIsSuperuserPermission(RequireLoginPermission):
+    async def verify_permission(self, request: Request):
+        await super().verify_permission(request)
+
+        if isinstance(self.user, StudentModel):
+            raise NotASuperuserException()
         
 
 class BaseRolePermission(RequireLoginPermission):

--- a/app/core/exceptions/__init__.py
+++ b/app/core/exceptions/__init__.py
@@ -5,3 +5,4 @@ from .user import *
 from .assignment import *
 from .submission import *
 from .course import *
+from .ldap import *

--- a/app/core/exceptions/ldap.py
+++ b/app/core/exceptions/ldap.py
@@ -1,0 +1,6 @@
+from .base import CustomException
+
+class LDAPConnectionTimeoutException(CustomException):
+    code = 500
+    error_code = "LDAP__CONNECTION_TIMEOUT"
+    message = "ldap connection timed out, try again shortly"

--- a/app/core/exceptions/user.py
+++ b/app/core/exceptions/user.py
@@ -29,3 +29,8 @@ class NotAnInstructorException(CustomException):
     code = 403
     error_code = "USER__NOT_AN_INSTRUCTOR"
     message = "user is not an instructor"
+
+class NotASuperuserException(CustomException):
+    code = 403
+    error_code = "USER__NOT_A_SUPERUSER"
+    message = "user is not a superuser"

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,6 +1,7 @@
 from .user import *
 from .jwt_service import *
 from .kubernetes_service import *
+from .ldap_service import *
 from .assignment_service import *
 from .submission_service import *
 from .course_service import *

--- a/app/services/course_service.py
+++ b/app/services/course_service.py
@@ -1,5 +1,3 @@
-from typing import List
-from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from app.models import CourseModel

--- a/app/services/ldap_service.py
+++ b/app/services/ldap_service.py
@@ -1,0 +1,52 @@
+import ldap3
+from ldap3.core.exceptions import LDAPSocketOpenError
+from pydantic import BaseModel
+from app.core.config import settings
+from app.core.exceptions import LDAPConnectionTimeoutException, UserNotFoundException
+
+class LDAPUserInfoSchema(BaseModel):
+    onyen: str
+    first_name: str
+    last_name: str
+    email: str
+
+class LDAPService:
+    def get_user_info(self, pid: str) -> LDAPUserInfoSchema:
+        base_dn = "dc=unc,dc=edu"
+        server = ldap3.Server(
+            host=settings.LDAP_HOST,
+            port=settings.LDAP_PORT,
+            get_info=ldap3.ALL,
+            connect_timeout=settings.LDAP_TIMEOUT_SECONDS
+        )
+        try:
+            with ldap3.Connection(
+                server,
+                user=settings.LDAP_SERVICE_ACCOUNT_BIND_DN,
+                password=settings.LDAP_SERVICE_ACCOUNT_PASSWORD,
+                auto_bind=True,
+                receive_timeout=settings.LDAP_TIMEOUT_SECONDS
+            ) as conn:
+                search_filter = f"(&(objectClass=uncperson)(pid={pid}))"
+                conn.search(
+                    search_base=base_dn,
+                    search_filter=search_filter,
+                    search_scope=ldap3.SUBTREE,
+                    attributes=[
+                        "uid", # onyen
+                        "givenName", # first name
+                        "sn", # surname
+                        "mail" # email
+                    ]
+                )
+                if len(conn.entries) == 0:
+                    raise UserNotFoundException()
+                student = conn.entries[0]
+                return LDAPUserInfoSchema(
+                    onyen=student.uid.value,
+                    first_name=student.givenName.value,
+                    last_name=student.sn.value,
+                    email=student.mail.value
+                )
+        except LDAPSocketOpenError as e:
+            raise LDAPConnectionTimeoutException()

--- a/app/services/ldap_service.py
+++ b/app/services/ldap_service.py
@@ -17,6 +17,7 @@ class LDAPService:
             host=settings.LDAP_HOST,
             port=settings.LDAP_PORT,
             get_info=ldap3.ALL,
+            use_ssl=settings.LDAP_PORT == 636,
             connect_timeout=settings.LDAP_TIMEOUT_SECONDS
         )
         try:

--- a/start.py
+++ b/start.py
@@ -2,6 +2,8 @@ import os
 import glob
 import subprocess
 import sys
+import uvicorn
+from app.main import app
 from dotenv import load_dotenv
 from alembic.config import Config
 from alembic import command


### PR DESCRIPTION
Moves LDAP functionality required for class roster import script in jupyter-lab-prof into endpoint here. Necessary because we need authenticated access to LDAP using a service account to ensure that we can always view student information, and we don't want to put the service account password into professor JLP pods where they can view it.