### PR TITLE
Allow .env.local file for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ celerybeat.pid
 # Environments
 .venv
 .env
+.env.local
 env/
 venv/
 ENV/

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,7 @@
 from typing import Optional, Any, Dict, List
 from enum import Enum
 from pydantic import BaseModel, BaseSettings, PostgresDsn, Json, validator, root_validator
+import os.path
 
 class DevPhase(str, Enum):
     DEV = "dev"
@@ -21,6 +22,13 @@ class SetupWizardData(BaseModel):
     instructors: List[SetupWizardInstructor]
 
 class Settings(BaseSettings):
+
+    def __init__(self) -> None:
+        if os.path.isfile(".env.local"):
+            super().__init__(".env.local")
+        else:
+            super().__init__()
+
     # General config
     API_V1_STR: str = "/api/v1"
     DEV_PHASE: DevPhase = DevPhase.PROD
@@ -46,8 +54,8 @@ class Settings(BaseSettings):
     LDAP_TIMEOUT_SECONDS: int = 5
 
     # Database
-    POSTGRES_HOST: str
-    POSTGRES_PORT: str = "5432"
+    POSTGRES_HOST: str 
+    POSTGRES_PORT: str
     POSTGRES_DB: str
     POSTGRES_USER: str
     POSTGRES_PASSWORD: str


### PR DESCRIPTION
As of this PR, devs can create a file called `.env.local` as a copy of `.env.sample` in the root of the project and set values for all of the environment variables that need to be set. Previously, we had to change the config.py file manually to have the default values during development and make sure not to upload them to source control which was a major hassle. This will become even more useful once Harit merges his testing PR, since it fixes this issue in the Testing pane of vscode. 

The way I have it, it shouldn't have any effect if the `.env.local` file is not there, but we should keep an eye on it once we deploy this to a hosted environment with environment variables like Kubernetes for the first time.