### PR TITLE
Actually fix setup wizard coroutine...

### DIFF
--- a/start.py
+++ b/start.py
@@ -48,9 +48,10 @@ def main(host, port, reload):
     command.upgrade(alembic_cfg, "head")
 
 
-    # Run setup wizard, if required, in the background
+    # Run setup wizard, if required.
     try:
-        asyncio.create_task(setup_wizard.run())
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(setup_wizard.run())
     except ValueError as e:
         print(str(e))
 


### PR DESCRIPTION
So the first fix didn't actually fix this. Anyways, I realized that `create_task` probably isn't the right approach regardless since we need the setup wizard to complete before the server starts up so that we can guarantee proper application state.