### PR TITLE
Add event system into API

### DIFF
--- a/app/core/dependencies/database.py
+++ b/app/core/dependencies/database.py
@@ -1,4 +1,6 @@
 from typing import Generator
+from sqlalchemy.orm import Session
+
 from app.database import SessionLocal
 
 def get_db() -> Generator:
@@ -7,3 +9,7 @@ def get_db() -> Generator:
         yield db
     finally:
         db.close()
+
+# DANGEROUS: You must call Session.close() when using this function or you will overflow the pool. 
+def get_db_persistent() -> Session:
+    return SessionLocal()

--- a/app/events/__init__.py
+++ b/app/events/__init__.py
@@ -1,2 +1,3 @@
 from .schemas import *
 from .handlers import *
+from .decorators import *

--- a/app/events/__init__.py
+++ b/app/events/__init__.py
@@ -1,0 +1,2 @@
+from .schemas import *
+from .handlers import *

--- a/app/events/decorators.py
+++ b/app/events/decorators.py
@@ -1,0 +1,9 @@
+from fastapi_events.dispatcher import dispatch
+
+# For use with static events.
+def dispatches(*args, **kwargs):
+    def inner(func):
+        result = func()
+        dispatch(*args, **kwargs)
+        return result
+    return inner

--- a/app/events/handlers.py
+++ b/app/events/handlers.py
@@ -1,8 +1,25 @@
+from fastapi import Depends
 from fastapi_events.handlers.local import local_handler
 from fastapi_events.typing import Event
+from sqlalchemy.orm import Session
+
 from .schemas import SyncEvents
+from app.models import AssignmentModel
+from app.services import AssignmentService
+from app.core.dependencies import get_db_persistent
+
+"""
+NOTE: Use `get_db_persistent` instead of `get_db`. FastAPI-Events does not support generator-based DI.
+You MUST call Session.close() once you are done with the database session. 
+"""
+
 
 @local_handler.register(event_name=SyncEvents.SYNC_CREATE_ASSIGNMENT)
-def handle_sync_create_assignment(event: Event):
+async def handle_sync_create_assignment(event: Event, session: Session = Depends(get_db_persistent)):
     event_name, payload = event
-    print("Handling sync event", event_name, "payload: ", payload)
+    assignment_id = payload["assignment_id"]
+
+    assignment = await AssignmentService(session).get_assignment_by_id(assignment_id)
+    print("Handling sync event <Create Assignment>, assignment name:", assignment.name)
+
+    session.close()

--- a/app/events/handlers.py
+++ b/app/events/handlers.py
@@ -1,0 +1,8 @@
+from fastapi_events.handlers.local import local_handler
+from fastapi_events.typing import Event
+from .schemas import SyncEvents
+
+@local_handler.register(event_name=SyncEvents.SYNC_CREATE_ASSIGNMENT)
+def handle_sync_create_assignment(event: Event):
+    event_name, payload = event
+    print("Handling sync event", event_name, "payload: ", payload)

--- a/app/events/schemas.py
+++ b/app/events/schemas.py
@@ -9,4 +9,4 @@ class SyncEvents(Enum):
 class SyncCreateAssignmentEvent(BaseModel):
     __event_name__ = SyncEvents.SYNC_CREATE_ASSIGNMENT
     
-    id: str
+    assignment_id: int

--- a/app/events/schemas.py
+++ b/app/events/schemas.py
@@ -1,0 +1,12 @@
+from enum import Enum
+from pydantic import BaseModel
+from fastapi_events.registry.payload_schema import registry
+
+class SyncEvents(Enum):
+    SYNC_CREATE_ASSIGNMENT = "SYNC_CREATE_ASSIGNMENT"
+
+@registry.register
+class SyncCreateAssignmentEvent(BaseModel):
+    __event_name__ = SyncEvents.SYNC_CREATE_ASSIGNMENT
+    
+    id: str

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,8 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware import Middleware
 from fastapi_pagination import add_pagination
+from fastapi_events.middleware import EventHandlerASGIMiddleware
+from fastapi_events.handlers.local import local_handler
 from starlette.middleware.cors import CORSMiddleware
 
 from app.api.api_v1 import api_router
@@ -49,6 +51,10 @@ def make_middleware() -> List[Middleware]:
             AuthenticationMiddleware,
             backend=AuthBackend(),
             on_error=on_auth_error
+        ),
+        Middleware(
+            EventHandlerASGIMiddleware,
+            handlers=[local_handler]
         )
     ]
 


### PR DESCRIPTION
Add event system into API using fastapi-events. Add an example event for reference on how to build out the system further.

To dispatch an event, do e.g.:
```python
from fastapi_events.dispatcher import dispatch
from app.events import SyncCreateAssignmentEvent

# inside an endpoint/service method/wherever
dispatch(SyncCreateAssignmentEvent(assignment_id=1234))
```
I've also added an `@dispatches(event)` decorator for usage with static event data:
```python
from app.events import dispatches, SyncEvents
@dispatches(SyncEvents.TRIGGERS_SYNC)
def my_function_that_causes_sync():
    ...
```
Again, note that this is only for events that will only be dispatched statically (i.e., the dispatched event payload is independent of whatever the method is doing).

Note: a drawback of this library is that it does not yet support generator dependencies, which is how FastAPI handles injections that require cleanup after the context completes. You will need to use the `get_db_persistent` dependency instead and manually call `session.close()` once you are done using it in event handlers.