### PR TITLE
Add dependency to requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ loguru==0.4.1
 ldap3==2.9
 pandas==2.2.2
 python-multipart==0.0.9
-fastapi_events==0.11.1
+fastapi-events==0.11.1
 git+https://github.com/helxplatform/eduhelx-utils.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ loguru==0.4.1
 ldap3==2.9
 pandas==2.2.2
 python-multipart==0.0.9
+fastapi_events==0.11.1
 git+https://github.com/helxplatform/eduhelx-utils.git


### PR DESCRIPTION
Grader-API build fails since it can't find `fastapi_events` - adding it to requirements file.