### PR TITLE
Add python3 kernel to requirements, fix grade_report numpy casting

### DIFF
--- a/app/models/grade_report.py
+++ b/app/models/grade_report.py
@@ -36,9 +36,9 @@ class GradeReportModel(Base):
         otter_config_content: str
     ) -> GradeReportModel:
         scores = [grade.score for grade in submission_grades]
-        average = np.mean(scores)
-        median = np.median(scores)
-        stdev = np.std(scores)
+        average = float(np.mean(scores))
+        median = float(np.median(scores))
+        stdev = float(np.std(scores))
         minimum, maximum = min(scores), max(scores)
         num_submitted = len(submission_grades)
         num_skipped = sum([grade.submission_already_graded for grade in submission_grades])

--- a/app/services/assignment_service.py
+++ b/app/services/assignment_service.py
@@ -208,7 +208,7 @@ class AssignmentService:
 
     """ Compute the default gitignore for an assignment. """
     async def get_gitignore_content(self, assignment: AssignmentModel) -> str:
-        protected_files = ["\n".join(file) for file in await self.get_protected_files(assignment)]
+        protected_files_str = "\n".join(await self.get_protected_files(assignment))
 
         return f"""### Defaults ###
 __pycache__/
@@ -217,16 +217,19 @@ __pycache__/
 *venv
 .ipynb_checkpoints
 .OTTER_LOG
+.nfs*
+# Backup file naming scheme is <original_name>~<datetime>~
+*~*~
 
 ### Protected ###
-{ protected_files }
+{ protected_files_str }
 """
     
     """
     NOTE: File paths are not necessarily real files and may instead be globs.
     NOTE: File paths are relative to `assignment.directory_path`.
     """
-    async def get_protected_files(self, assignment: AssignmentModel) -> str:
+    async def get_protected_files(self, assignment: AssignmentModel) -> List[str]:
         return [
             "*grades.csv",
             "*grading_config.json",

--- a/app/services/course_service.py
+++ b/app/services/course_service.py
@@ -32,7 +32,7 @@ class CourseService:
 
     
     async def create_course(self, name: str, start_at: datetime = None, end_at: datetime = None) -> CourseModel:
-        from app.services import GiteaService, CleanupService
+        from app.services import GiteaService, CleanupService, FileOperation, FileOperationType
 
         try:
             await self.get_course()
@@ -59,6 +59,10 @@ class CourseService:
 
         master_repository_name = self._compute_master_repository_name(name)
         instructor_organization_name = self._compute_instructor_gitea_organization_name(name)
+        master_branch_name = self._compute_master_branch_name()
+        file_operations = [
+            FileOperation(content=".ssh\n", path=".gitignore", operation=FileOperationType.CREATE)
+        ]
 
         try:
             await gitea_service.create_organization(instructor_organization_name)
@@ -76,6 +80,13 @@ class CourseService:
                 private=True
             )
             print("CREATED CLASS MASTER REPOSITORY")
+            await gitea_service.modify_repository_files(
+                name=master_repository_name,
+                owner=instructor_organization_name,
+                branch_name=master_branch_name,
+                commit_message="Initial commit",
+                files=file_operations
+            )
             await gitea_service.set_git_hook(
                 repository_name=master_repository_name,
                 owner=instructor_organization_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,6 @@ otter-grader==5.5.0
 python-dateutil===2.9.0
 numpy==2.0.0
 fastapi-events==0.11.1
+jupyter-server
+ipykernel
 git+https://github.com/helxplatform/eduhelx-utils.git


### PR DESCRIPTION
A couple fixes that were required for getting the grader API running in Manning again. Note that the numpy boolean issue is not fixed, I just adjusted the test cases to use numpy's boolean type instead of python's.

Notes:
- We can remove ipykernel/jupyter-server installs once grading is not done directly on the grader API. They are quite hefty.
- For some reason, Otter won't cast `np.True_` to `True`, causing some test cases to fail. We've been using `otter-grader==5.5.0` across the board so something else must be causing this disparity between grading locally and in Manning. One thing to check is numpy versions, as Manning is using 2.0.0 while I run 1.25.2 locally. 