### PR TITLE
update canvas API call to include additional records per request

### DIFF
--- a/app/services/canvas_service.py
+++ b/app/services/canvas_service.py
@@ -71,6 +71,12 @@ class CanvasService:
         return res.json()
     
     async def _get(self, endpoint: str, **kwargs):
+        if 'params' not in kwargs:
+            kwargs['params'] = {}
+        
+        # Set or override the 'per_page' parameter to 100
+        kwargs['params']['per_page'] = 100
+
         return await self._make_request("GET", endpoint, **kwargs)
 
     async def _post(self, endpoint: str, **kwargs):


### PR DESCRIPTION
This change add a `per_page=100` param to every GET request we make to Canvas. While not every request (like GET course) requires this, this approach makes it very easy to add/remove this on every request.

When we add proper paginated request/responses, this change will be super easy to undo.

Tested, doesn't break any existing endpoints we hit.