### PR TITLE
Remove body from request and response of all log messages 

### DIFF
--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -7,44 +7,44 @@ from app.core.middleware.iterator_wrapper import iterator_wrapper as aiwrap
 
 class LogMiddleware(BaseHTTPMiddleware):
     # https://github.com/tiangolo/fastapi/issues/394#issuecomment-927272627
-    async def set_body(self, request: Request):
-        receive_ = await request._receive()
+    # async def set_body(self, request: Request):
+    #     receive_ = await request._receive()
 
-        async def receive() -> Message:
-            return receive_
+    #     async def receive() -> Message:
+    #         return receive_
 
-        request._receive = receive
+    #     request._receive = receive
 
     async def dispatch(self, request, call_next):
             start_time = time.time()
 
-            await self.set_body(request)
-            req_body = await request.body()
+            # await self.set_body(request)
+            # req_body = await request.body()
             response = await call_next(request)
 
             # Consuming FastAPI response and grabbing body here
-            resp_body = [section async for section in response.__dict__['body_iterator']]
+            # resp_body = [section async for section in response.__dict__['body_iterator']]
             # Repairing FastAPI response
-            response.__setattr__('body_iterator', aiwrap(resp_body))
+            # response.__setattr__('body_iterator', aiwrap(resp_body))
 
             # Formatting response body for logging
-            try:
-                resp_body = json.loads(resp_body[0].decode())
-            except:
-                resp_body = str(resp_body)
+            # try:
+            #     resp_body = json.loads(resp_body[0].decode())
+            # except:
+            #     resp_body = str(resp_body)
 
             request.app.logger.info(
                 {
                     "req": {
                         "method": request.method, 
                         "url": str(request.url),
-                        "body": req_body,
+                        # "body": req_body,
                         "user": request.user.onyen if hasattr(request.user, "onyen") else None,
                     },
                     "res": {
-                        "status_code": response.status_code,
-                        "response_time": f"{round((time.time() - start_time) * 1000)} ms",
-                        "body": resp_body
+                        "status_code": response.status_code
+                        # "response_time": f"{round((time.time() - start_time) * 1000)} ms",
+                        # "body": resp_body
                     }
                 }
             )

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -6,6 +6,11 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from app.core.middleware.iterator_wrapper import iterator_wrapper as aiwrap
 
 class LogMiddleware(BaseHTTPMiddleware):
+
+    # Leaving the code in here that sets up the request and response body just in
+    # case we want to use it in the future. But for now it's taking up way too much
+    # log space for no benefit.
+
     # https://github.com/tiangolo/fastapi/issues/394#issuecomment-927272627
     # async def set_body(self, request: Request):
     #     receive_ = await request._receive()


### PR DESCRIPTION
Confirmed locally that this takes the body out of the request and response. Makes the logs a ton easier to look at and ascertain when something happened.