### PR TITLE
Fix logging middleware and add file logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ log/*
 venv
 .idea/
 *.DS_Store
+.vscode
 
 # Helm for a while
 chart/Chart.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update && apt-get install -y rsync
 # Add the current directory contents into the container at /app
 ADD . .
 
-# Remove the .env.sample file from the image if it exists
-RUN ls .env.sample && rm .env.sample
+# Remove the .env.sample and .env files from the image if they exist
+RUN rm -f .env.sample && rm -f .env
 
+# Create the debug.log file and make it group read-writable
 RUN mkdir logs && touch logs/debug.log && chmod g+rw logs/debug.log
 
 # Install any needed packages specified in requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y rsync
 
 # Add the current directory contents into the container at /app
-ADD . /app
+ADD . .
+
+# Remove the .env.sample file from the image if it exists
+RUN ls .env.sample && rm .env.sample
+
+RUN mkdir logs && touch logs/debug.log && chmod g+rw logs/debug.log
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
@@ -16,7 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 EXPOSE 8080
 
 # Define environment variable
-ENV NAME World
+ENV NAME=World
 
 # Run start.py when the container launches
 CMD ["python", "start.py"]

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from .endpoints import (
     submission_router, assignment_router, user_router,
     student_router, instructor_router, course_router,
-    settings_router, auth_router, lms_router
+    settings_router, auth_router, lms_router, health_router
 )
 
 api_router = APIRouter()
@@ -15,3 +15,4 @@ api_router.include_router(course_router.router, tags=["course"])
 api_router.include_router(settings_router.router, tags=["settings"])
 api_router.include_router(auth_router.router, tags=["auth"])
 api_router.include_router(lms_router.router, tags=["lms"])
+api_router.include_router(health_router.router, tags=["health"])

--- a/app/api/api_v1/endpoints/health_router.py
+++ b/app/api/api_v1/endpoints/health_router.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+@router.get("/health/live", response_model=None, status_code=200)
+async def heathcheckLive():
+  pass
+
+@router.get("/health/ready", response_model=None, status_code=200)
+async def heathcheckReady():
+  # In the future, check the health of redis and other internal systems here
+  pass

--- a/app/api/api_v1/endpoints/health_router.py
+++ b/app/api/api_v1/endpoints/health_router.py
@@ -4,10 +4,10 @@ from fastapi import APIRouter
 router = APIRouter()
 
 @router.get("/health/live", response_model=None, status_code=200)
-async def heathcheckLive():
+async def healthcheck_live():
   pass
 
 @router.get("/health/ready", response_model=None, status_code=200)
-async def heathcheckReady():
+async def healthcheck_ready():
   # In the future, check the health of redis and other internal systems here
   pass

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -1,59 +1,130 @@
 import json
+import logging
 import time
+from typing import Callable
+from uuid import uuid4
+from fastapi import FastAPI, Response
 from starlette.types import Message
 from starlette.requests import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from app.core.middleware.iterator_wrapper import iterator_wrapper as aiwrap
+from app.core.utils.async_iterator_wrapper import AsyncIteratorWrapper
 
 class LogMiddleware(BaseHTTPMiddleware):
 
-    # Leaving the code in here that sets up the request and response body just in
-    # case we want to use it in the future. But for now it's taking up way too much
-    # log space for no benefit.
+    def __init__(self, app: FastAPI, *, logger) -> None:
+        self._logger = logger
+        super().__init__(app)
 
     # https://github.com/tiangolo/fastapi/issues/394#issuecomment-927272627
-    # async def set_body(self, request: Request):
-    #     receive_ = await request._receive()
+    async def set_body(self, request: Request):
+        receive_ = await request._receive()
 
-    #     async def receive() -> Message:
-    #         return receive_
+        async def receive() -> Message:
+            return receive_
 
-    #     request._receive = receive
+        request._receive = receive
 
     async def dispatch(self, request, call_next):
-            start_time = time.time()
+        request_id: str = str(uuid4())
+        logging_dict = {
+            "X-API-REQUEST-ID": request_id  # X-API-REQUEST-ID maps each request-response to a unique ID
+        }
 
-            # await self.set_body(request)
-            # req_body = await request.body()
-            response = await call_next(request)
+        await self.set_body(request)
+        response, response_dict = await self._create_response_log(
+            call_next,
+            request,
+            request_id
+        )
+        request_dict = await self._create_request_log(request)
+        logging_dict["req"] = request_dict
+        logging_dict["res"] = response_dict
 
-            # Consuming FastAPI response and grabbing body here
-            # resp_body = [section async for section in response.__dict__['body_iterator']]
-            # Repairing FastAPI response
-            # response.__setattr__('body_iterator', aiwrap(resp_body))
+        # urlStr = str(request.url)
+        # if urlStr[-5:] != "/docs":
+            # self._logger.info(
+            #     {
+            #         "req": {
+            #             "method": request.method, 
+            #             "url": str(request.url),
+            #             # "body": req_body,
+            #             "user": request.user.onyen if hasattr(request.user, "onyen") else None,
+            #         },
+            #         "res": {
+            #             "status_code": response.status_code
+            #             # "response_time": f"{round((time.time() - start_time) * 1000)} ms",
+            #             # "body": resp_body
+            #         }
+            #     }
+            # )
+        self._logger.info(logging_dict)
 
-            # Formatting response body for logging
-            # try:
-            #     resp_body = json.loads(resp_body[0].decode())
-            # except:
-            #     resp_body = str(resp_body)
+        return response
+    
+    async def _create_request_log(self, request: Request) -> dict:
 
-            request.app.logger.info(
+        path = request.url.path
+        if request.query_params:
+            path += f"?{request.query_params}"
+
+        request_log_dict = {
+            "method": request.method
+        }
+
+        try:
+            body = await request.json()
+            request_log_dict["body"] = body
+        except:
+            body = None
+
+        return request_log_dict
+    
+    async def _create_response_log(self,
+                            call_next: Callable,
+                            request: Request,
+                            request_id: str
+                            ) -> Response:
+
+        start_time = time.perf_counter()
+        response = await self._execute_request(call_next, request, request_id)
+        finish_time = time.perf_counter()
+
+        execution_time = finish_time - start_time
+
+        response_log_dict = {
+            "status_code": response.status_code,
+            "execution_time": f"{execution_time:0.4f}s"
+        }
+
+        resp_body = [section async for section in response.__dict__["body_iterator"]]
+        response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
+
+        try:
+            resp_body = json.loads(resp_body[0].decode())
+        except:
+            resp_body = str(resp_body)
+
+        response_log_dict["body"] = resp_body
+
+        return response, response_log_dict
+
+    async def _execute_request(self,
+                               call_next: Callable,
+                               request: Request,
+                               request_id: str
+                               ) -> Response:
+        try:
+            response: Response = await call_next(request)
+
+            response.headers["X-API-Request-ID"] = request_id
+            return response
+
+        except Exception as e:
+            self._logger.exception(
                 {
-                    "req": {
-                        "method": request.method, 
-                        "url": str(request.url),
-                        # "body": req_body,
-                        "user": request.user.onyen if hasattr(request.user, "onyen") else None,
-                    },
-                    "res": {
-                        "status_code": response.status_code
-                        # "response_time": f"{round((time.time() - start_time) * 1000)} ms",
-                        # "body": resp_body
-                    }
+                    "path": request.url.path,
+                    "method": request.method,
+                    "reason": e
                 }
             )
-
-            return response
-    
     

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -29,23 +29,23 @@ class LogMiddleware(BaseHTTPMiddleware):
         if request.url.path.startswith("/api/v1/health"):
             response = await self._execute_request(call_next, request)
             return response
-        
-        request_id: str = str(uuid4())
-        logging_dict = {
-            "X-API-REQUEST-ID": request_id  # X-API-REQUEST-ID maps each request-response to a unique ID
-        }
 
         await self.set_body(request)
+
+        request_id: str = str(uuid4())
         response, response_dict = await self._create_response_log(
             call_next,
             request,
             request_id
         )
-        request_dict = await self._create_request_log(request)
-        logging_dict["req"] = request_dict
-        logging_dict["res"] = response_dict
 
+        logging_dict = {
+            "X-API-REQUEST-ID": request_id,  # X-API-REQUEST-ID maps each request-response to a unique ID
+            "req": await self._create_request_log(request),
+            "res": response_dict
+        }
         self._logger.info(logging_dict)
+
         if self._file_logger is not None:
             resp_body = [section async for section in response.__dict__["body_iterator"]]
             response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -28,7 +28,7 @@ class LogMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         if request.url.path.startswith("/api/v1/health"):
             response = await self._execute_request(call_next, request)
-            return
+            return response
         
         request_id: str = str(uuid4())
         logging_dict = {

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -84,21 +84,17 @@ class LogMiddleware(BaseHTTPMiddleware):
     
     async def _create_request_log(self, request: Request) -> str:
 
-        path = request.url.path
-        if request.query_params:
-            path += f"?{request.query_params}"
-
         request_log_dict = {
             "method": request.method,
-            "endpoint": path,
+            "endpoint": request.url.path,
             "user": request.user.onyen if hasattr(request.user, "onyen") else None,
         }
 
         try:
-            body = await request.json()
-            request_log_dict["body"] = body
-        except:
-            body = None
+            if request.url.path not in self._get_endpoints_to_not_log_req_body():
+                body = await request.json()
+                request_log_dict["body"] = body
+        except Exception as e:
             request_log_dict["body"] = None
 
         return request_log_dict
@@ -142,3 +138,8 @@ class LogMiddleware(BaseHTTPMiddleware):
             }
             self._logger.exception(exception_log)
     
+    def _get_endpoints_to_not_log_req_body(self) -> list[str]:
+        return [
+            "/api/v1/login",
+            "api/v1/refresh"
+        ]

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -70,7 +70,7 @@ class LogMiddleware(BaseHTTPMiddleware):
 
         request_log_dict = {
             "method": request.method,
-            "endpoint": request.url.path,
+            "endpoint": path,
             "user": request.user.onyen if hasattr(request.user, "onyen") else None,
         }
 

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -141,5 +141,5 @@ class LogMiddleware(BaseHTTPMiddleware):
     def _get_endpoints_to_not_log_req_body(self) -> list[str]:
         return [
             "/api/v1/login",
-            "api/v1/refresh"
+            "/api/v1/refresh"
         ]

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -61,7 +61,7 @@ class LogMiddleware(BaseHTTPMiddleware):
 
         return response
     
-    async def _create_request_log(self, request: Request) -> dict:
+    async def _create_request_log(self, request: Request) -> str:
 
         path = request.url.path
         if request.query_params:

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -1,16 +1,12 @@
 import json
 import logging
-from pydoc import classname
 import time
 from typing import Callable
 from uuid import uuid4
 from fastapi import FastAPI, Response
-from fastapi.responses import JSONResponse
 from starlette.types import Message
 from starlette.requests import Request
 from starlette.middleware.base import BaseHTTPMiddleware
-from app.core.config import settings, DevPhase
-from app.core.exceptions.base import CustomException
 from app.core.utils.async_iterator_wrapper import AsyncIteratorWrapper
 
 class LogMiddleware(BaseHTTPMiddleware):

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -1,12 +1,16 @@
 import json
 import logging
+from pydoc import classname
 import time
 from typing import Callable
 from uuid import uuid4
 from fastapi import FastAPI, Response
+from fastapi.responses import JSONResponse
 from starlette.types import Message
 from starlette.requests import Request
 from starlette.middleware.base import BaseHTTPMiddleware
+from app.core.config import settings, DevPhase
+from app.core.exceptions.base import CustomException
 from app.core.utils.async_iterator_wrapper import AsyncIteratorWrapper
 
 class LogMiddleware(BaseHTTPMiddleware):
@@ -25,19 +29,47 @@ class LogMiddleware(BaseHTTPMiddleware):
 
         request._receive = receive
 
-    async def dispatch(self, request, call_next):
+    async def dispatch(self, request: Request, call_next: Callable):
         if request.url.path.startswith("/api/v1/health"):
             response = await self._execute_request(call_next, request)
             return response
 
         await self.set_body(request)
 
-        request_id: str = str(uuid4())
+        request_id = str(uuid4())
         response, response_dict = await self._create_response_log(
             call_next,
             request,
             request_id
         )
+
+        resp_body = [section async for section in response.__dict__["body_iterator"]]
+        response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
+
+        try:
+            resp_body = json.loads(resp_body[0])
+        except:
+            resp_body = str(resp_body)
+
+        if "error_code" in resp_body:
+            # If the response contains an error code, that means an exception happened
+            # and we need to log it. So just log the exception and return, don't log
+            # the request as you would normally.
+            request_log = {
+                "path": request.url.path,
+                "method": request.method,
+            }
+            if type(resp_body) is dict:
+                request_log["error_code"] = resp_body["error_code"]
+                request_log["message"] = resp_body["message"]
+                self._logger.error(request_log)
+                self._logger.error(resp_body["stack"])
+            elif type(resp_body) is str:
+                # If the resp_body is of type str because the above json.loads() failed, 
+                # don't add the fields above, just use the whole resp_body
+                request_log["resp_body"] = resp_body
+                self._logger.error(request_log)
+            return response
 
         logging_dict = {
             "X-API-REQUEST-ID": request_id,  # X-API-REQUEST-ID maps each request-response to a unique ID
@@ -47,14 +79,6 @@ class LogMiddleware(BaseHTTPMiddleware):
         self._logger.info(logging_dict)
 
         if self._file_logger is not None:
-            resp_body = [section async for section in response.__dict__["body_iterator"]]
-            response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
-
-            try:
-                resp_body = json.loads(resp_body[0])
-            except:
-                resp_body = str(resp_body)
-
             response_dict["body"] = resp_body
             logging_dict["res"] = response_dict
 
@@ -83,11 +107,12 @@ class LogMiddleware(BaseHTTPMiddleware):
 
         return request_log_dict
     
-    async def _create_response_log(self,
-                            call_next: Callable,
-                            request: Request,
-                            request_id
-                            ) -> Response:
+    async def _create_response_log(
+        self,
+        call_next: Callable,
+        request: Request,
+        request_id
+    ) -> Response:
 
         start_time = time.perf_counter()
         response = await self._execute_request(call_next, request, request_id)
@@ -102,24 +127,22 @@ class LogMiddleware(BaseHTTPMiddleware):
 
         return response, response_log_dict
 
-    async def _execute_request(self,
-                               call_next: Callable,
-                               request: Request,
-                               request_id: str = None
-                               ) -> Response:
+    async def _execute_request(
+        self,
+        call_next: Callable,
+        request: Request,
+        request_id: str = None
+    ) -> Response:
         try:
             response: Response = await call_next(request)
-
             if request_id is not None:
                 response.headers["X-API-Request-ID"] = request_id
             return response
-
         except Exception as e:
-            self._logger.exception(
-                {
-                    "path": request.url.path,
-                    "method": request.method,
-                    "reason": e
-                }
-            )
+            exception_log = {
+                "path": request.url.path,
+                "method": request.method,
+                "reason": e
+            }
+            self._logger.exception(exception_log)
     

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -11,8 +11,9 @@ from app.core.utils.async_iterator_wrapper import AsyncIteratorWrapper
 
 class LogMiddleware(BaseHTTPMiddleware):
 
-    def __init__(self, app: FastAPI, *, logger) -> None:
+    def __init__(self, app: FastAPI, *, logger: logging.Logger, file_logger: logging.Logger = None) -> None:
         self._logger = logger
+        self._file_logger = file_logger
         super().__init__(app)
 
     # https://github.com/tiangolo/fastapi/issues/394#issuecomment-927272627
@@ -25,6 +26,10 @@ class LogMiddleware(BaseHTTPMiddleware):
         request._receive = receive
 
     async def dispatch(self, request, call_next):
+        if "health" in request.url.path:
+            response = await self._execute_request(call_next, request, request_id)
+            return
+        
         request_id: str = str(uuid4())
         logging_dict = {
             "X-API-REQUEST-ID": request_id  # X-API-REQUEST-ID maps each request-response to a unique ID
@@ -40,24 +45,20 @@ class LogMiddleware(BaseHTTPMiddleware):
         logging_dict["req"] = request_dict
         logging_dict["res"] = response_dict
 
-        # urlStr = str(request.url)
-        # if urlStr[-5:] != "/docs":
-            # self._logger.info(
-            #     {
-            #         "req": {
-            #             "method": request.method, 
-            #             "url": str(request.url),
-            #             # "body": req_body,
-            #             "user": request.user.onyen if hasattr(request.user, "onyen") else None,
-            #         },
-            #         "res": {
-            #             "status_code": response.status_code
-            #             # "response_time": f"{round((time.time() - start_time) * 1000)} ms",
-            #             # "body": resp_body
-            #         }
-            #     }
-            # )
         self._logger.info(logging_dict)
+        if self._file_logger is not None:
+            resp_body = [section async for section in response.__dict__["body_iterator"]]
+            response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
+
+            try:
+                resp_body = json.loads(resp_body[0])
+            except:
+                resp_body = str(resp_body)
+
+            response_dict["body"] = resp_body
+            logging_dict["res"] = response_dict
+
+            self._file_logger.debug(logging_dict)
 
         return response
     
@@ -68,7 +69,9 @@ class LogMiddleware(BaseHTTPMiddleware):
             path += f"?{request.query_params}"
 
         request_log_dict = {
-            "method": request.method
+            "method": request.method,
+            "endpoint": request.url.path,
+            "user": request.user.onyen if hasattr(request.user, "onyen") else None,
         }
 
         try:
@@ -76,6 +79,7 @@ class LogMiddleware(BaseHTTPMiddleware):
             request_log_dict["body"] = body
         except:
             body = None
+            request_log_dict["body"] = None
 
         return request_log_dict
     
@@ -93,18 +97,8 @@ class LogMiddleware(BaseHTTPMiddleware):
 
         response_log_dict = {
             "status_code": response.status_code,
-            "execution_time": f"{execution_time:0.4f}s"
+            "execution_time": f"{execution_time:0.4f}s",
         }
-
-        # resp_body = [section async for section in response.__dict__["body_iterator"]]
-        # response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
-
-        # try:
-        #     resp_body = json.loads(resp_body[0].decode())
-        # except:
-        #     resp_body = str(resp_body)
-
-        # response_log_dict["body"] = resp_body
 
         return response, response_log_dict
 

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -96,15 +96,15 @@ class LogMiddleware(BaseHTTPMiddleware):
             "execution_time": f"{execution_time:0.4f}s"
         }
 
-        resp_body = [section async for section in response.__dict__["body_iterator"]]
-        response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
+        # resp_body = [section async for section in response.__dict__["body_iterator"]]
+        # response.__setattr__("body_iterator", AsyncIteratorWrapper(resp_body))
 
-        try:
-            resp_body = json.loads(resp_body[0].decode())
-        except:
-            resp_body = str(resp_body)
+        # try:
+        #     resp_body = json.loads(resp_body[0].decode())
+        # except:
+        #     resp_body = str(resp_body)
 
-        response_log_dict["body"] = resp_body
+        # response_log_dict["body"] = resp_body
 
         return response, response_log_dict
 

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -27,7 +27,7 @@ class LogMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request, call_next):
         if request.url.path.startswith("/api/v1/health"):
-            response = await self._execute_request(call_next, request, request_id)
+            response = await self._execute_request(call_next, request)
             return
         
         request_id: str = str(uuid4())
@@ -86,7 +86,7 @@ class LogMiddleware(BaseHTTPMiddleware):
     async def _create_response_log(self,
                             call_next: Callable,
                             request: Request,
-                            request_id: str
+                            request_id
                             ) -> Response:
 
         start_time = time.perf_counter()
@@ -105,12 +105,13 @@ class LogMiddleware(BaseHTTPMiddleware):
     async def _execute_request(self,
                                call_next: Callable,
                                request: Request,
-                               request_id: str
+                               request_id: str = None
                                ) -> Response:
         try:
             response: Response = await call_next(request)
 
-            response.headers["X-API-Request-ID"] = request_id
+            if request_id is not None:
+                response.headers["X-API-Request-ID"] = request_id
             return response
 
         except Exception as e:

--- a/app/core/middleware/logger.py
+++ b/app/core/middleware/logger.py
@@ -26,7 +26,7 @@ class LogMiddleware(BaseHTTPMiddleware):
         request._receive = receive
 
     async def dispatch(self, request, call_next):
-        if "health" in request.url.path:
+        if request.url.path.startswith("/api/v1/health"):
             response = await self._execute_request(call_next, request, request_id)
             return
         

--- a/app/core/utils/async_iterator_wrapper.py
+++ b/app/core/utils/async_iterator_wrapper.py
@@ -1,4 +1,9 @@
-class iterator_wrapper:
+class AsyncIteratorWrapper:
+    """The following is a utility class that transforms a
+        regular iterable to an asynchronous one.
+
+        link: https://www.python.org/dev/peps/pep-0492/#example-2
+    """
 
     def __init__(self, obj):
         self._it = iter(obj)

--- a/app/main.py
+++ b/app/main.py
@@ -16,19 +16,13 @@ from app.core.exceptions import CustomException
 import logging
 from pathlib import Path
 
-# root_logger = logging.getLogger()
-# root_logger.disabled = True
-logging.getLogger().removeHandler(logging.getLogger().handlers[0])
-logger = logging.getLogger("uvicorn")
+logging.getLogger("uvicorn.access").disabled = True
+logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
 stream_handler = logging.StreamHandler(sys.stdout)
 stream_handler.setFormatter(formatter)
-file_handler = logging.FileHandler("info.log")
-file_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
-logger.addHandler(file_handler)
-
 
 def init_routers(app: FastAPI):
     app.include_router(api_router, prefix=settings.API_V1_STR)

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ def init_uvicorn_logger(formatter) -> logging.Logger:
 
 def init_file_logger(formatter) -> logging.Logger | None:
     file_logger = None
-    if settings.DEV_PHASE == "prod":
+    if settings.DEV_PHASE == DevPhase.PROD:
         file_logger = logging.getLogger("file-logger")
         file_logger.handlers.clear()
         file_logger.setLevel(logging.DEBUG)

--- a/app/main.py
+++ b/app/main.py
@@ -27,14 +27,16 @@ def init_logging():
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
 
-def init_uvicorn_logger(formatter):
+def init_uvicorn_logger(formatter) -> logging.Logger:
     logger = logging.getLogger("uvicorn")
     logger.setLevel(logging.INFO)
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
+    return logger
 
-def init_file_logger(formatter):
+def init_file_logger(formatter) -> logging.Logger | None:
+    file_logger = None
     if settings.DEV_PHASE == "prod":
         file_logger = logging.getLogger("file-logger")
         file_logger.handlers.clear()
@@ -42,8 +44,8 @@ def init_file_logger(formatter):
         file_handler = RotatingFileHandler("logs/debug.log", maxBytes=1024*1024*100, backupCount=4)
         file_handler.setFormatter(formatter)
         file_logger.addHandler(file_handler)
-    else:
-        file_logger = None
+    return file_logger
+    
     
 init_logging()
 uvicorn_logger = init_uvicorn_logger(formatter)

--- a/app/main.py
+++ b/app/main.py
@@ -11,21 +11,23 @@ from starlette.middleware.cors import CORSMiddleware
 from app.api.api_v1 import api_router
 from app.core.config import settings, DevPhase
 from app.core.middleware import AuthenticationMiddleware, AuthBackend, LogMiddleware
-from eduhelx_utils.custom_logger import CustomizeLogger
 from app.core.exceptions import CustomException
 
 import logging
 from pathlib import Path
 
-logger = logging.getLogger("root")
-# logger.setLevel(logging.INFO)
-# formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-# stream_handler = logging.StreamHandler(sys.stdout)
-# stream_handler.setFormatter(formatter)
-# file_handler = logging.FileHandler("info.log")
-# file_handler.setFormatter(formatter)
-# logger.addHandler(stream_handler)
-# logger.addHandler(file_handler)
+# root_logger = logging.getLogger()
+# root_logger.disabled = True
+logging.getLogger().removeHandler(logging.getLogger().handlers[0])
+logger = logging.getLogger("uvicorn")
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+stream_handler = logging.StreamHandler(sys.stdout)
+stream_handler.setFormatter(formatter)
+file_handler = logging.FileHandler("info.log")
+file_handler.setFormatter(formatter)
+logger.addHandler(stream_handler)
+logger.addHandler(file_handler)
 
 
 def init_routers(app: FastAPI):

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
+from logging.handlers import RotatingFileHandler
 import sys
 from typing import List
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware import Middleware
 from fastapi_pagination import add_pagination
@@ -17,12 +18,31 @@ import logging
 from pathlib import Path
 
 logging.getLogger("uvicorn.access").disabled = True
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+
+# Configure logging
 formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+root_logger = logging.getLogger()
+root_logger.disabled = True
+for handler in root_logger.handlers[:]:
+    root_logger.removeHandler(handler)
+
+
+logger = logging.getLogger("uvicorn")
+logger.setLevel(logging.INFO)
 stream_handler = logging.StreamHandler(sys.stdout)
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
+
+if settings.DEV_PHASE == "prod":
+    file_logger = logging.getLogger("file-logger")
+    file_logger.handlers.clear()
+    file_logger.setLevel(logging.DEBUG)
+    file_handler = RotatingFileHandler("logs/debug.log", maxBytes=1024*1024*100, backupCount=4)
+    file_handler.setFormatter(formatter)
+    file_logger.addHandler(file_handler)
+else:
+    file_logger = None
+
 
 def init_routers(app: FastAPI):
     app.include_router(api_router, prefix=settings.API_V1_STR)
@@ -64,7 +84,8 @@ def make_middleware() -> List[Middleware]:
         ),
         Middleware(
             LogMiddleware, 
-            logger=logger
+            logger=logger,
+            file_logger=file_logger
         )
     ]
 
@@ -83,10 +104,6 @@ async def custom_exception_handler(request: Request, exc: CustomException):
         content=content,
     )
 
-# if not settings.DISABLE_LOGGER:
-    # logger = CustomizeLogger.make_logger(config_path)
-    # app.logger = logger
-    # app.add_middleware(LogMiddleware, logger=logger)
 init_monkeypatch()
 init_routers(app)
 add_pagination(app)

--- a/app/main.py
+++ b/app/main.py
@@ -53,6 +53,17 @@ file_logger = init_file_logger(formatter)
 
 def init_routers(app: FastAPI):
     app.include_router(api_router, prefix=settings.API_V1_STR)
+
+def init_listeners():
+    @app.exception_handler(CustomException)
+    async def custom_exception_handler(request: Request, exc: CustomException):
+        content = { "error_code": exc.error_code, "message": exc.message }
+        if settings.DEV_PHASE == DevPhase.DEV:
+            content["stack"] = exc.stack
+        return JSONResponse(
+            status_code=exc.code,
+            content=content,
+        )
     
 def init_monkeypatch():
     ### Monkey patch serializers for custom types
@@ -96,26 +107,14 @@ def make_middleware() -> List[Middleware]:
         )
     ]
 
-def init_listeners():
-    @app.exception_handler(CustomException)
-    async def custom_exception_handler(request: Request, exc: CustomException):
-        content = { "error_code": exc.error_code, "message": exc.message }
-        if settings.DEV_PHASE == DevPhase.DEV:
-            content["stack"] = exc.stack
-        return JSONResponse(
-            status_code=exc.code,
-            content=content,
-        )
-
 def create_app() -> FastAPI:
-
     app = FastAPI(
         openapi_url=f"{ settings.API_V1_STR }/openapi.json",
         middleware=make_middleware()
     )
-    init_listeners()
     init_monkeypatch()
     init_routers(app)
+    init_listeners()
     add_pagination(app)
 
     return app

--- a/app/main.py
+++ b/app/main.py
@@ -15,8 +15,6 @@ from app.core.middleware import AuthenticationMiddleware, AuthBackend, LogMiddle
 from app.core.exceptions import CustomException
 
 import logging
-from pathlib import Path
-
 
 formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
 
@@ -54,7 +52,7 @@ file_logger = init_file_logger(formatter)
 def init_routers(app: FastAPI):
     app.include_router(api_router, prefix=settings.API_V1_STR)
 
-def init_listeners():
+def init_listeners(app: FastAPI):
     @app.exception_handler(CustomException)
     async def custom_exception_handler(request: Request, exc: CustomException):
         content = { "error_code": exc.error_code, "message": exc.message }
@@ -114,7 +112,7 @@ def create_app() -> FastAPI:
     )
     init_monkeypatch()
     init_routers(app)
-    init_listeners()
+    init_listeners(app)
     add_pagination(app)
 
     return app

--- a/app/main.py
+++ b/app/main.py
@@ -96,21 +96,28 @@ def make_middleware() -> List[Middleware]:
         )
     ]
 
-app = FastAPI(
-    openapi_url=f"{ settings.API_V1_STR }/openapi.json",
-    middleware=make_middleware()
-)
+def init_listeners():
+    @app.exception_handler(CustomException)
+    async def custom_exception_handler(request: Request, exc: CustomException):
+        content = { "error_code": exc.error_code, "message": exc.message }
+        if settings.DEV_PHASE == DevPhase.DEV:
+            content["stack"] = exc.stack
+        return JSONResponse(
+            status_code=exc.code,
+            content=content,
+        )
 
-@app.exception_handler(CustomException)
-async def custom_exception_handler(request: Request, exc: CustomException):
-    content = { "error_code": exc.error_code, "message": exc.message }
-    if settings.DEV_PHASE == DevPhase.DEV:
-        content["stack"] = exc.stack
-    return JSONResponse(
-        status_code=exc.code,
-        content=content,
+def create_app() -> FastAPI:
+
+    app = FastAPI(
+        openapi_url=f"{ settings.API_V1_STR }/openapi.json",
+        middleware=make_middleware()
     )
+    init_listeners()
+    init_monkeypatch()
+    init_routers(app)
+    add_pagination(app)
 
-init_monkeypatch()
-init_routers(app)
-add_pagination(app)
+    return app
+
+app = create_app()

--- a/app/main.py
+++ b/app/main.py
@@ -17,32 +17,37 @@ from app.core.exceptions import CustomException
 import logging
 from pathlib import Path
 
-logging.getLogger("uvicorn.access").disabled = True
 
-# Configure logging
 formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-root_logger = logging.getLogger()
-root_logger.disabled = True
-for handler in root_logger.handlers[:]:
-    root_logger.removeHandler(handler)
 
+def init_logging():
+    logging.getLogger("uvicorn.access").disabled = True
+    root_logger = logging.getLogger()
+    root_logger.disabled = True
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
 
-logger = logging.getLogger("uvicorn")
-logger.setLevel(logging.INFO)
-stream_handler = logging.StreamHandler(sys.stdout)
-stream_handler.setFormatter(formatter)
-logger.addHandler(stream_handler)
+def init_uvicorn_logger(formatter):
+    logger = logging.getLogger("uvicorn")
+    logger.setLevel(logging.INFO)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
 
-if settings.DEV_PHASE == "prod":
-    file_logger = logging.getLogger("file-logger")
-    file_logger.handlers.clear()
-    file_logger.setLevel(logging.DEBUG)
-    file_handler = RotatingFileHandler("logs/debug.log", maxBytes=1024*1024*100, backupCount=4)
-    file_handler.setFormatter(formatter)
-    file_logger.addHandler(file_handler)
-else:
-    file_logger = None
-
+def init_file_logger(formatter):
+    if settings.DEV_PHASE == "prod":
+        file_logger = logging.getLogger("file-logger")
+        file_logger.handlers.clear()
+        file_logger.setLevel(logging.DEBUG)
+        file_handler = RotatingFileHandler("logs/debug.log", maxBytes=1024*1024*100, backupCount=4)
+        file_handler.setFormatter(formatter)
+        file_logger.addHandler(file_handler)
+    else:
+        file_logger = None
+    
+init_logging()
+uvicorn_logger = init_uvicorn_logger(formatter)
+file_logger = init_file_logger(formatter)
 
 def init_routers(app: FastAPI):
     app.include_router(api_router, prefix=settings.API_V1_STR)
@@ -84,7 +89,7 @@ def make_middleware() -> List[Middleware]:
         ),
         Middleware(
             LogMiddleware, 
-            logger=logger,
+            logger=uvicorn_logger,
             file_logger=file_logger
         )
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ loguru==0.4.1
 ldap3==2.9
 pandas==2.2.2
 python-multipart==0.0.9
+python-json-logger==2.0.7
 otter-grader==5.5.0
 python-dateutil===2.9.0
 numpy==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ loguru==0.4.1
 ldap3==2.9
 pandas==2.2.2
 python-multipart==0.0.9
-python-json-logger==2.0.7
 otter-grader==5.5.0
 python-dateutil===2.9.0
 numpy==2.0.0

--- a/start.py
+++ b/start.py
@@ -8,6 +8,34 @@ from alembic import command
 from app.services import LmsSyncService
 from app.database import SessionLocal
 
+logging_config = {
+  "version": 1,
+  "disable_existing_loggers": True,
+  "formatters": {
+    "json": {
+      "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+      "format": "%(asctime)s %(levelname)s %(message)s"
+    }
+  },
+  "handlers": {
+    "default": {
+      "level": "INFO",
+      "class": "logging.StreamHandler",
+      "formatter": "json",
+      "stream": "sys.stdout"
+    }
+  },
+  "loggers": { 
+    "uvicorn": {
+      "handlers": ["default"],
+      "level": "INFO",
+      "propagate": True
+    }
+  },
+  "rotation": "20 days",
+  "retention": "12 months"
+}
+
 def positive_int(value):
     ivalue = int(value)
     if ivalue <= 0: raise argparse.ArgumentTypeError(f"{ value } must be a positive integer")
@@ -58,7 +86,7 @@ def main(host: str, port: int, reload: bool, workers: int | None=None):
         print(str(e))
 
     # Start the application
-    uvicorn.run("app.main:app", host=host, port=port, reload=reload, workers=workers)
+    uvicorn.run("app.main:app", host=host, port=port, reload=reload, workers=workers, log_config=logging_config)
 
 
 if __name__ == "__main__":

--- a/start.py
+++ b/start.py
@@ -12,32 +12,68 @@ from alembic import command
 from app.services import LmsSyncService
 from app.database import SessionLocal
 
-logging_config = {
-  "version": 1,
-  "disable_existing_loggers": True,
-  "formatters": {
-    "default": {
-      "format": "%(asctime)s %(levelname)s %(message)s"
-    }
-  },
-  "handlers": {
-    "default": {
-      "level": "INFO",
-      "class": "logging.StreamHandler",
-      "formatter": "default",
-      "stream": sys.stdout
-    }
-  },
-  "loggers": { 
-    "uvicorn": {
-      "handlers": ["default"],
-      "level": "INFO",
-      "propagate": True
-    },
-  }
-#   "rotation": "20 days",
-#   "retention": "12 months"
-}
+log_config = uvicorn.config.LOGGING_CONFIG
+log_config["loggers"]["uvicorn.access"]["level"] = "CRITICAL"
+# log_config = {
+#   'version': 1, 
+#   'disable_existing_loggers': True, 
+#   'formatters': {
+#     'default': {
+#       '()': 'uvicorn.logging.DefaultFormatter', 
+#       'fmt': '%(asctime)s %(levelname)s %(message)s', 
+#       'use_colors': True
+#     },
+#   }, 
+#   'handlers': {
+#     'default': {
+#       'formatter': 'default', 
+#       'class': 'logging.StreamHandler', 
+#       'stream': sys.stdout
+#     },
+#     'error': {
+#       'formatter': 'default', 
+#       'class': 'logging.StreamHandler', 
+#       'stream': sys.stderr
+#     },
+#   }, 
+#   'loggers': {
+#     'uvicorn': {
+#       'handlers': ['default'], 
+#       'level': 'INFO', 
+#       'propagate': False
+#     }, 
+#     'uvicorn.error': {
+#       'handlers': ['error'],
+#       'level': 'INFO'
+#     }, 
+#   }
+# }
+# logging_config = {
+#   "version": 1,
+#   "disable_existing_loggers": True,
+#   "formatters": {
+#     "default": {
+#       "format": "%(asctime)s %(levelname)s %(message)s"
+#     }
+#   },
+#   "handlers": {
+#     "default": {
+#       "level": "INFO",
+#       "class": "logging.StreamHandler",
+#       "formatter": "default",
+#       "stream": sys.stdout
+#     }
+#   },
+#   "loggers": { 
+#     "uvicorn": {
+#       "handlers": ["default"],
+#       "level": "INFO",
+#       "propagate": True
+#     },
+#   }
+# #   "rotation": "20 days",
+# #   "retention": "12 months"
+# }
 
 def positive_int(value):
     ivalue = int(value)
@@ -89,7 +125,7 @@ def main(host: str, port: int, reload: bool, workers: int | None=None):
         print(str(e))
 
     # Start the application
-    uvicorn.run("app.main:app", host=host, port=port, reload=reload, workers=workers)
+    uvicorn.run("app.main:app", host=host, port=port, reload=reload, workers=workers, log_config=None)
 
 
 if __name__ == "__main__":

--- a/start.py
+++ b/start.py
@@ -1,5 +1,9 @@
+import logging
 import os
 import glob
+import sys
+import pythonjsonlogger
+import pythonjsonlogger.jsonlogger
 import uvicorn
 import asyncio
 from dotenv import load_dotenv
@@ -12,8 +16,7 @@ logging_config = {
   "version": 1,
   "disable_existing_loggers": True,
   "formatters": {
-    "json": {
-      "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+    "default": {
       "format": "%(asctime)s %(levelname)s %(message)s"
     }
   },
@@ -21,8 +24,8 @@ logging_config = {
     "default": {
       "level": "INFO",
       "class": "logging.StreamHandler",
-      "formatter": "json",
-      "stream": "sys.stdout"
+      "formatter": "default",
+      "stream": sys.stdout
     }
   },
   "loggers": { 
@@ -30,10 +33,10 @@ logging_config = {
       "handlers": ["default"],
       "level": "INFO",
       "propagate": True
-    }
-  },
-  "rotation": "20 days",
-  "retention": "12 months"
+    },
+  }
+#   "rotation": "20 days",
+#   "retention": "12 months"
 }
 
 def positive_int(value):
@@ -86,7 +89,7 @@ def main(host: str, port: int, reload: bool, workers: int | None=None):
         print(str(e))
 
     # Start the application
-    uvicorn.run("app.main:app", host=host, port=port, reload=reload, workers=workers, log_config=logging_config)
+    uvicorn.run("app.main:app", host=host, port=port, reload=reload, workers=workers)
 
 
 if __name__ == "__main__":

--- a/start.py
+++ b/start.py
@@ -1,9 +1,5 @@
-import logging
 import os
 import glob
-import sys
-import pythonjsonlogger
-import pythonjsonlogger.jsonlogger
 import uvicorn
 import asyncio
 from dotenv import load_dotenv
@@ -12,68 +8,6 @@ from alembic import command
 from app.services import LmsSyncService
 from app.database import SessionLocal
 
-log_config = uvicorn.config.LOGGING_CONFIG
-log_config["loggers"]["uvicorn.access"]["level"] = "CRITICAL"
-# log_config = {
-#   'version': 1, 
-#   'disable_existing_loggers': True, 
-#   'formatters': {
-#     'default': {
-#       '()': 'uvicorn.logging.DefaultFormatter', 
-#       'fmt': '%(asctime)s %(levelname)s %(message)s', 
-#       'use_colors': True
-#     },
-#   }, 
-#   'handlers': {
-#     'default': {
-#       'formatter': 'default', 
-#       'class': 'logging.StreamHandler', 
-#       'stream': sys.stdout
-#     },
-#     'error': {
-#       'formatter': 'default', 
-#       'class': 'logging.StreamHandler', 
-#       'stream': sys.stderr
-#     },
-#   }, 
-#   'loggers': {
-#     'uvicorn': {
-#       'handlers': ['default'], 
-#       'level': 'INFO', 
-#       'propagate': False
-#     }, 
-#     'uvicorn.error': {
-#       'handlers': ['error'],
-#       'level': 'INFO'
-#     }, 
-#   }
-# }
-# logging_config = {
-#   "version": 1,
-#   "disable_existing_loggers": True,
-#   "formatters": {
-#     "default": {
-#       "format": "%(asctime)s %(levelname)s %(message)s"
-#     }
-#   },
-#   "handlers": {
-#     "default": {
-#       "level": "INFO",
-#       "class": "logging.StreamHandler",
-#       "formatter": "default",
-#       "stream": sys.stdout
-#     }
-#   },
-#   "loggers": { 
-#     "uvicorn": {
-#       "handlers": ["default"],
-#       "level": "INFO",
-#       "propagate": True
-#     },
-#   }
-# #   "rotation": "20 days",
-# #   "retention": "12 months"
-# }
 
 def positive_int(value):
     ivalue = int(value)


### PR DESCRIPTION
* Disable other loggers like the root logger and `uvicorn.access` so that it doesn't log every API request twice
* Add request ID to every request; this could eventually be propagated through Celery so that each job has that request ID associated with it and we can trace which request created the job and when looking through logs after the fact can correlate logs in workers to specific requests
* Remove the response body from the stdout logs, but keep the request body
* Add a file logger so that the full request with the response body is logged in a rotating file on disk (in /app/logs/debug.log)
* Add health endpoints so that we can stop calling /docs for the liveness and readiness probes