### PR TITLE
Adding github actions

### DIFF
--- a/.github/workflows/build-push-dev-image.yml
+++ b/.github/workflows/build-push-dev-image.yml
@@ -1,0 +1,27 @@
+# Workflow responsible for the 
+# development release processes.
+
+name: Build-Push-Dev-Image
+on:
+   push:
+    branches:
+      - develop
+      - develop-'v[0-9]+'
+    paths-ignore:
+      - README.md
+      - .old_cicd/*
+      - .github/*
+      - .github/workflows/*
+      - LICENSE
+      - .gitignore
+      - .dockerignore
+      - .githooks
+   # Do not build another image on a pull request.
+   # Any push to develop will trigger a new build however.
+   pull_request:
+     branches-ignore:
+       - '*'
+jobs:
+   build-push-dev-image:
+    uses: helxplatform/helx-github-actions/.github/workflows/build-push-dev-image.yml@main
+    secrets: inherit

--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -1,0 +1,27 @@
+# Workflow responsible for the 
+# major release processes.
+#
+
+name: Build-Push-Release
+on:
+  push:
+    branches:
+      - master 
+      - main
+      - master-'v[0-9]+'
+    paths-ignore:
+      - README.md
+      - .old_cicd/*
+      - .github/*
+      - .github/workflows/*
+      - LICENSE
+      - .gitignore
+      - .dockerignore
+      - .githooks
+    tags-ignore:
+      - 'v[0-9]+.[0-9]+.*'
+      - '*'
+jobs:
+  build-push-release:
+    uses: helxplatform/helx-github-actions/.github/workflows/build-push-release.yml@main
+    secrets: inherit

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,0 +1,45 @@
+# Workflow responsible for core acceptance testing.
+# Tests Currently Run:
+#     - flake8-linter
+#     - image-build-test
+#    
+# This workflow will build a test image for everything but develop
+# and main branches. The tag will be test_{your_branch_name}
+#
+# The build-push-dev-image and build-push-release workflows 
+# handle the develop and release image storage respectively.
+#
+#
+
+name: Code-Checks-Remote
+on:
+    push:
+     branches-ignore:
+      - master-'v[0-9]+'
+      - master
+      - main
+      - develop
+      - develop-'v[0-9]+'
+     paths-ignore:
+      - README.md
+      - .old_cicd/*
+      - .github/*
+      - .github/workflows/*
+      - LICENSE
+      - .gitignore
+      - .dockerignore
+      - .githooks
+    pull_request:
+     branches:
+      - develop-'v[0-9]+'
+      - develop
+      - master
+      - master-'v[0-9]+'
+      - main 
+     types: [ opened, synchronize ]
+         
+jobs:
+  
+  code-checks:
+    uses: helxplatform/helx-github-actions/.github/workflows/code-checks.yml@main
+    secrets: inherit

--- a/.github/workflows/trivy-pr-scan.yml
+++ b/.github/workflows/trivy-pr-scan.yml
@@ -1,0 +1,25 @@
+
+name: trivy-pr-scan 
+on:
+  pull_request:
+    branches:
+      - develop-'v[0-9]+'
+      - develop
+      - master
+      - master-'v[0-9]+'
+      - main 
+    types: [ opened, synchronize ]
+    paths-ignore:
+    - README.md
+    - .old_cicd/*
+    - .github/*
+    - .github/workflows/*
+    - LICENSE
+    - .gitignore
+    - .dockerignore
+    - .githooks
+
+jobs:
+  trivy-pr-scan:
+    uses: helxplatform/helx-github-actions/.github/workflows/trivy-pr-scan.yml@main
+    secrets: inherit


### PR DESCRIPTION
Ref: https://renci.atlassian.net/browse/CICD-250 

Using the mechanism that discovers the branch automatically for our code-checks here to automatically detect and tag the appropriate branches. We are not releasing a 'github release object' however due to the nature of the master-v1, master scheme. If that is something desired - ie you want more on github site itself, we can talk about it. 